### PR TITLE
Performance optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Allows to pass a list of xmlid to import
  - Allows to do csv imports in script mode
+ - load_batch method now returns response from API
+ - Caching of external_ids is now executed only when explicitly needed
+ - Caching of modules is now executed only when explicitly needed
 
 ## [3.6.1] - 2024-09-30
 

--- a/src/odoo_configurator/apps/datas.py
+++ b/src/odoo_configurator/apps/datas.py
@@ -60,14 +60,7 @@ class OdooDatas(base.OdooModule):
 
     def execute_update_config_datas(self):
         self.logger.info("Apply %s" % self._name)
-        self.get_external_config_xmlid_cache()
         self.execute(self._datas)
-
-    def get_external_config_xmlid_cache(self):
-        domain = [['module', '=', 'external_config']]
-        datas = self.execute_odoo('ir.model.data', 'search_read', [domain, ['name', 'res_id']], {'context': {}})
-        for data in datas:
-            self._configurator.xmlid_cache['external_config.%s' % data['name']] = data['res_id']
 
     def execute_config(self, config):
         if config:
@@ -245,6 +238,8 @@ class OdooDatas(base.OdooModule):
             if '.' not in force_id:
                 force_id = "external_config." + force_id
             values['id'] = force_id
+            if not self._configurator.xmlid_cache: #load xml_id cache
+                self._configurator.get_external_config_xmlid_cache()
             if force_id in self._configurator.xmlid_cache:
                 return values, self._configurator.xmlid_cache[force_id]
             module, name = force_id.split('.')

--- a/src/odoo_configurator/apps/modules.py
+++ b/src/odoo_configurator/apps/modules.py
@@ -107,7 +107,7 @@ class OdooModules(base.OdooModule):
             for module in modules:
                 self.logger.info('\t\t* %s' % module)
                 if self._uninstalled_modules_cache.get(module).get('state') != 'uninstalled':
-                    to_uninstall.append(self._modules_cache.get(module).get('id'))
+                    to_uninstall.append(self._uninstalled_modules_cache.get(module).get('id'))
 
             for m in to_uninstall:
                 self.execute_odoo('ir.module.module', 'button_immediate_uninstall', [m], no_raise=True)

--- a/src/odoo_configurator/apps/modules.py
+++ b/src/odoo_configurator/apps/modules.py
@@ -32,7 +32,8 @@ class OdooModules(base.OdooModule):
         self.uninstall_modules(datas)
 
     def install_modules(self, config):
-        self.install_odoo(config.get('modules', []))
+        if config.get('modules', []):
+            self.install_odoo(config.get('modules', []))
         for key in config:
             if isinstance(config.get(key), dict) or isinstance(config.get(key), OrderedDict):
                 modules = config.get(key).get('modules', [])
@@ -50,7 +51,8 @@ class OdooModules(base.OdooModule):
                     self.update_module_odoo(modules)
 
     def uninstall_modules(self, config):
-        self.uninstall_odoo(config.get('uninstall_modules', []))
+        if config.get('uninstall_modules', []):
+            self.uninstall_odoo(config.get('uninstall_modules', []))
         for key in config:
             if isinstance(config.get(key), dict) or isinstance(config.get(key), OrderedDict):
                 modules = config.get(key).get('uninstall_modules', [])

--- a/src/odoo_configurator/configurator.py
+++ b/src/odoo_configurator/configurator.py
@@ -215,6 +215,12 @@ class Configurator:
     def get_log(self):
         return "\n".join(self.log_history)
 
+    def get_external_config_xmlid_cache(self):
+        domain = [['module', '=', 'external_config']]
+        xmlid_datas = self.connection.execute_odoo('ir.model.data', 'search_read', [domain, ['name', 'res_id']], {'context': {}})
+        for xmlid_data in xmlid_datas:
+            self.xmlid_cache['external_config.%s' % xmlid_data['name']] = xmlid_data['res_id']
+
     def show(self):
         pass
         # logger.info('show')

--- a/src/odoo_configurator/import_manager.py
+++ b/src/odoo_configurator/import_manager.py
@@ -153,7 +153,7 @@ class ImportManager:
             # print(load_keys)
             # print(data)
             load_datas[-1].append([data[i] for i in load_keys])
-
+        res = {}
         cc = 0
         for load_data in load_datas:
             start_batch = datetime.now()
@@ -184,6 +184,7 @@ class ImportManager:
 
         stop = datetime.now()
         self.logger.info("\t\t\tTotal time %s" % (stop - start))
+        return res
 
     def set_params(self, params):
 

--- a/src/odoo_configurator/odoo_connection.py
+++ b/src/odoo_configurator/odoo_connection.py
@@ -180,6 +180,8 @@ class OdooConnection:
         return self.execute_odoo(model, 'search', args, {'context': context})
 
     def get_ref(self, external_id):
+        if not self.xmlid_cache:  # load xml_id cache
+            self._configurator.get_external_config_xmlid_cache()
         if external_id in self.xmlid_cache:
             return self.xmlid_cache[external_id]
         res = self.execute_odoo('ir.model.data',


### PR DESCRIPTION
### problème rencontré:
En phase de dev, j'ai déjà importé un gros volume de données dans mon Odoo, je travaille modèle par modèle sur d'autres imports.
A chaque fois que je veux tester mon nouveau script d'import (très souvent), le configurator se lance et commence par mettre en cache tous les external ids existants (+30k): cela prends plusieurs secondes.
Le configurator récupère  également la liste de tous les modules, même si il n'y a aucun module à installer ou désinstaller, cela prends du temps aussi.

### solution proposée:
- external ids caching:
    - J'ai bougé dans la classe Configurator la méthode qui mets en cache les external_ids
    - J'ai supprimé l'appel systématique de cette méthode lors de l'initialisation de la classe Datas
la mise en cache est maintenant déclenchée uniquement lorsque nécessaire (si get_ref() ou set_force_id() sont appelés)
- préchargement des modules
    - j'ai ajouté un check pour vérifier si les modules sont sollicités dans la config 

=> c'est très discutable comme fix mais ça me fait gagner vraiment beaucoup de temps sur le projet CGF

### Autre
- la méthode load_batch ne renvoyait pas la réponse de l'API, je l'ai ajouté.
