### PR TITLE
New class utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+ - Added a new class for utility functions => utils.py
+ - new method get_env_var() to get variable environment from yaml files
+
+## [3.6.2] - 2024-11-04
+
+### Added
+
  - Allows to pass a list of xmlid to import
  - Allows to do csv imports in script mode
  - load_batch method now returns response from API

--- a/src/odoo_configurator/apps/base.py
+++ b/src/odoo_configurator/apps/base.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 from ..odoo_connection import OdooConnection
 from ..keepass import KeepassCli
 from ..bitwarden import Bitwarden
+from ..utils import Utils
 
 from ..logging import get_logger
 
@@ -18,6 +19,7 @@ class OdooModule:
     def __init__(self, configurator):
         self._configurator = configurator
         self._connection = configurator.connection
+        self._utils = configurator.utils
         self._keepass_cli = configurator.keepass_cli
         self._bitwarden_cli = configurator.bitwarden_cli
         self._import_manager = configurator.import_manager
@@ -51,10 +53,10 @@ class OdooModule:
         raise NotImplementedError
 
     def _published_objects(self):
-        return self._connection, self._keepass_cli, self._bitwarden_cli
+        return self._connection, self._keepass_cli, self._bitwarden_cli, self._utils
 
     def _published_class(self):
-        return OdooConnection, KeepassCli, Bitwarden
+        return OdooConnection, KeepassCli, Bitwarden, Utils
 
     def install_mode(self):
         if 'install' in self._mode:

--- a/src/odoo_configurator/configurator.py
+++ b/src/odoo_configurator/configurator.py
@@ -33,6 +33,7 @@ from .odoo_connection import OdooConnection
 from .odoo_connection import get_dir_full_path
 from .keepass import KeepassCli
 from .bitwarden import Bitwarden
+from .utils import Utils
 
 logger = get_logger(__name__)
 
@@ -73,6 +74,7 @@ class Configurator:
         self.log_history = []
         logger.setLevel(logging.DEBUG if debug else logging.INFO)
 
+        self.utils = Utils(self)
         self.keepass_cli = KeepassCli(self, keepass_password=keepass)
         self.bitwarden_cli = Bitwarden(self)
         self.prepare_odoo_connection()

--- a/src/odoo_configurator/utils.py
+++ b/src/odoo_configurator/utils.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2024 - Scalizer (<https://www.scalizer.fr>).
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from .logging import get_logger
+import os
+
+
+class Utils:
+    """This class is intended to provide utility functions which are not related to a specific configurator app.
+    Methods starting with 'get_' will automatically be callable from within yaml files,
+    as per similar methods in OdooConnection Class (get_ref, get_record, etc.) """
+
+    def __init__(self, configurator):
+        self.configurator = configurator
+        self.logger = get_logger("Utils".ljust(20))
+
+    def get_env_var(self, var_name):
+        var = os.environ.get(var_name)
+        if not var:
+            self.logger.warning(f"{var} Environment Variable not found or empty")
+        return var


### PR DESCRIPTION
Problème rencontré: 
- Dans le cadre de l'utilisation du configurator dans Github Codespaces, il était nécessaire de pouvoir récupérer le mot de passe d'authentification depuis les secrets du repo (via les variables d'env)

Solution proposée:
- Ajout d'une nouvelle classe Utils, instanciée lors de l'initialisation du configurator
- Cette classe est destinée à contenir des fonctions diverses, non spécifiquement liées à des "apps" du_ configurators
- création d'une méthode get_env_var
- L'objet utils est ajouté aux "published_objects" dont les méthodes commencant par 'get' sont automatiquement callable depuis le yaml.