### PR TITLE
[FIX] Import module no longer auto-apply when initialized before scripts execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+ - Import module no longer auto-apply when initialized before scripts execution
+
 ### Added
 
  - Added a new class for utility functions => utils.py

--- a/src/odoo_configurator/apps/datas.py
+++ b/src/odoo_configurator/apps/datas.py
@@ -44,7 +44,7 @@ class OdooDatas(base.OdooModule):
         odoo_config = OdooConfig(self._configurator, auto_apply=False)
         odoo_modules = OdooModules(self._configurator)
         odoo_users = OdooUsers(self._configurator)
-        odoo_imports = OdooImports(self._configurator)
+        odoo_imports = OdooImports(self._configurator, auto_apply=False)
         for script in scripts:
             self.logger.info("Script - %s" % script.get('title'))
             odoo_modules.install_config_modules(script)

--- a/src/odoo_configurator/apps/imports.py
+++ b/src/odoo_configurator/apps/imports.py
@@ -13,6 +13,10 @@ from ..sql import SqlConnection
 class OdooImports(base.OdooModule):
     _name = "Imports"
 
+    def __init__(self, configurator, auto_apply=True):
+        self.auto_apply = auto_apply
+        super().__init__(configurator)
+
     def get_func(self, data):
         if data.get('specific_import', False):
             if data.get('file_path', ''):


### PR DESCRIPTION
Problème rencontré:
- L'import s'exécute 2 fois car le module import est auto-apply lors de son initialisation juste avant l'exécution des scripts

Solution proposée:
- ajout de la possibilité de désactiver l'auto-apply du module Imports lors de l'initialisation.