### PR TITLE
Manage context language for extra OdooConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+- Extra OdooConnection context language can now be set by adding 'lang' in the auth section.
+
 ## [3.7.3]
 
 ### Added 

--- a/src/odoo_configurator/apps/imports.py
+++ b/src/odoo_configurator/apps/imports.py
@@ -76,6 +76,7 @@ class OdooImports(base.OdooModule):
                                                auth_values['username'],
                                                auth_values['password'],
                                                version=auth_values.get('version', False),
+                                               lang=auth_values.get('lang', 'fr_FR'),
                                                ))
                     except ConnectionError:
                         exit(1)


### PR DESCRIPTION
Hey,
Dans la continuité de la PR #14, j'ai besoin de pouvoir changer aussi la langue des "extra connections", donc je propose de pouvoir directement le préciser dans la section "auth" du YAML